### PR TITLE
Drop defunct Travis badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jplot
-[![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/jplot/master/LICENSE) [![Build Status](https://travis-ci.org/rs/jplot.svg?branch=master)](https://travis-ci.org/rs/jplot)
+[![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/jplot/master/LICENSE)
 
 Jplot tracks expvar-like (JSON) metrics and plot their evolution over time right into your iTerm2 terminal (or DRCS Sixel Graphics).
 


### PR DESCRIPTION
This PR removes the gray and useless build badge for Travis CI.